### PR TITLE
feat: change parser name rules

### DIFF
--- a/SQLiteLexer.g4
+++ b/SQLiteLexer.g4
@@ -135,10 +135,10 @@ WHERE_:             'WHERE';
 WITH_:              'WITH';
 
 IDENTIFIER:
-    '"' (~'"' | '""')* '"'
+    '"' (~'"' | '""')* '"' // Delimited identifiers
     | '`' (~'`' | '``')* '`'
     | '[' ~']'* ']'
-    | [A-Z_] [A-Z_0-9]*
+    | [A-Z_] [A-Z_0-9]* // Ordinary identifiers
 ; // TODO check: needs more chars in set
 
 NUMERIC_LITERAL: ((DIGIT+ ('.' DIGIT*)?) | ('.' DIGIT+)) ('E' [-+]? DIGIT+)? | '0x' HEX_DIGIT+;

--- a/SQLiteParser.g4
+++ b/SQLiteParser.g4
@@ -246,7 +246,7 @@ column_name_list:
 ;
 
 qualified_table_name:
-    table_name (AS_ alias)?
+    table_name (AS_ table_alias)?
     (INDEXED_ BY_ index_name | NOT_ INDEXED_)?
 ;
 
@@ -270,50 +270,40 @@ asc_desc:
     | DESC_
 ;
 
-// unknown
 
-column_alias:
-    IDENTIFIER
-    | STRING_LITERAL
-;
-
-keyword_function_name:
+// function_keywords are keywords also function names
+function_keyword:
     GLOB_
     | LIKE_
     | REPLACE_
 ;
 
 function_name:
-    keyword_function_name
-    | any_name
+    IDENTIFIER
+    | function_keyword
 ;
 
 table_name:
-    any_name
-;
-
-column_name:
-    any_name
-;
-
-collation_name:
-    any_name
-;
-
-index_name:
-    any_name
+    IDENTIFIER
 ;
 
 table_alias:
-    any_name
-;
-
-alias:
-    any_name
-;
-
-any_name:
     IDENTIFIER
-    | STRING_LITERAL
-    | OPEN_PAR any_name CLOSE_PAR
 ;
+
+column_name:
+    IDENTIFIER
+;
+
+column_alias:
+    IDENTIFIER
+;
+
+collation_name:
+    IDENTIFIER
+;
+
+index_name:
+    IDENTIFIER
+;
+


### PR DESCRIPTION
To enforce the rule required by kwilteam/kwil-db#315 , this pr changes antlr Parser rules on names:
- table name
- table name alias
- column name
- column name alias
- collation_name
- index_name
- function_name

Only `IDENTIFIER` could be used as those names. This complies sql 92 standard.