### PR TITLE
expr type hint

### DIFF
--- a/SQLiteLexer.g4
+++ b/SQLiteLexer.g4
@@ -53,6 +53,7 @@ GT_EQ:     '>=';
 EQ:        '==';
 NOT_EQ1:   '!=';
 NOT_EQ2:   '<>';
+TYPE_CAST: '::';
 
 // http://www.sqlite.org/lang_keywords.html
 ABORT_:             'ABORT';


### PR DESCRIPTION
support type hint syntax like `table.col::int` for expr:
- literal
- bind parameter
- column name
- expr wrapped in parentheses
- function call